### PR TITLE
fix: record resources with invalid urls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21139,9 +21139,9 @@
             }
         },
         "node_modules/webpack-dev-middleware": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-6.0.1.tgz",
-            "integrity": "sha512-PZPZ6jFinmqVPJZbisfggDiC+2EeGZ1ZByyMP5sOFJcPPWSexalISz+cvm+j+oYPT7FIJyxT76esjnw9DhE5sw==",
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-6.1.2.tgz",
+            "integrity": "sha512-Wu+EHmX326YPYUpQLKmKbTyZZJIB8/n6R09pTmB03kJmnMsVPTo9COzHZFr01txwaCAuZvfBJE4ZCHRcKs5JaQ==",
             "dev": true,
             "dependencies": {
                 "colorette": "^2.0.10",
@@ -21159,6 +21159,11 @@
             },
             "peerDependencies": {
                 "webpack": "^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "webpack": {
+                    "optional": true
+                }
             }
         },
         "node_modules/webpack-dev-middleware/node_modules/ajv": {
@@ -38102,9 +38107,9 @@
             }
         },
         "webpack-dev-middleware": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-6.0.1.tgz",
-            "integrity": "sha512-PZPZ6jFinmqVPJZbisfggDiC+2EeGZ1ZByyMP5sOFJcPPWSexalISz+cvm+j+oYPT7FIJyxT76esjnw9DhE5sw==",
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-6.1.2.tgz",
+            "integrity": "sha512-Wu+EHmX326YPYUpQLKmKbTyZZJIB8/n6R09pTmB03kJmnMsVPTo9COzHZFr01txwaCAuZvfBJE4ZCHRcKs5JaQ==",
             "dev": true,
             "requires": {
                 "colorette": "^2.0.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6980,21 +6980,21 @@
             }
         },
         "node_modules/body-parser": {
-            "version": "1.20.0",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
-            "integrity": "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==",
+            "version": "1.20.2",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
+            "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
             "dev": true,
             "dependencies": {
                 "bytes": "3.1.2",
-                "content-type": "~1.0.4",
+                "content-type": "~1.0.5",
                 "debug": "2.6.9",
                 "depd": "2.0.0",
                 "destroy": "1.2.0",
                 "http-errors": "2.0.0",
                 "iconv-lite": "0.4.24",
                 "on-finished": "2.4.1",
-                "qs": "6.10.3",
-                "raw-body": "2.5.1",
+                "qs": "6.11.0",
+                "raw-body": "2.5.2",
                 "type-is": "~1.6.18",
                 "unpipe": "1.0.0"
             },
@@ -7928,9 +7928,9 @@
             ]
         },
         "node_modules/content-type": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-            "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+            "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
             "dev": true,
             "engines": {
                 "node": ">= 0.6"
@@ -8305,9 +8305,9 @@
             }
         },
         "node_modules/cookie": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-            "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+            "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
             "dev": true,
             "engines": {
                 "node": ">= 0.6"
@@ -10269,17 +10269,17 @@
             }
         },
         "node_modules/express": {
-            "version": "4.18.1",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.18.1.tgz",
-            "integrity": "sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==",
+            "version": "4.19.2",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
+            "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
             "dev": true,
             "dependencies": {
                 "accepts": "~1.3.8",
                 "array-flatten": "1.1.1",
-                "body-parser": "1.20.0",
+                "body-parser": "1.20.2",
                 "content-disposition": "0.5.4",
                 "content-type": "~1.0.4",
-                "cookie": "0.5.0",
+                "cookie": "0.6.0",
                 "cookie-signature": "1.0.6",
                 "debug": "2.6.9",
                 "depd": "2.0.0",
@@ -10295,7 +10295,7 @@
                 "parseurl": "~1.3.3",
                 "path-to-regexp": "0.1.7",
                 "proxy-addr": "~2.0.7",
-                "qs": "6.10.3",
+                "qs": "6.11.0",
                 "range-parser": "~1.2.1",
                 "safe-buffer": "5.2.1",
                 "send": "0.18.0",
@@ -17671,9 +17671,9 @@
             }
         },
         "node_modules/qs": {
-            "version": "6.10.3",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
-            "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+            "version": "6.11.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+            "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
             "dev": true,
             "dependencies": {
                 "side-channel": "^1.0.4"
@@ -17749,9 +17749,9 @@
             }
         },
         "node_modules/raw-body": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-            "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+            "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
             "dev": true,
             "dependencies": {
                 "bytes": "3.1.2",
@@ -27434,21 +27434,21 @@
             }
         },
         "body-parser": {
-            "version": "1.20.0",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
-            "integrity": "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==",
+            "version": "1.20.2",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
+            "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
             "dev": true,
             "requires": {
                 "bytes": "3.1.2",
-                "content-type": "~1.0.4",
+                "content-type": "~1.0.5",
                 "debug": "2.6.9",
                 "depd": "2.0.0",
                 "destroy": "1.2.0",
                 "http-errors": "2.0.0",
                 "iconv-lite": "0.4.24",
                 "on-finished": "2.4.1",
-                "qs": "6.10.3",
-                "raw-body": "2.5.1",
+                "qs": "6.11.0",
+                "raw-body": "2.5.2",
                 "type-is": "~1.6.18",
                 "unpipe": "1.0.0"
             },
@@ -28130,9 +28130,9 @@
             }
         },
         "content-type": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-            "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+            "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
             "dev": true
         },
         "conventional-changelog": {
@@ -28437,9 +28437,9 @@
             }
         },
         "cookie": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-            "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+            "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
             "dev": true
         },
         "cookie-signature": {
@@ -29922,17 +29922,17 @@
             }
         },
         "express": {
-            "version": "4.18.1",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.18.1.tgz",
-            "integrity": "sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==",
+            "version": "4.19.2",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
+            "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
             "dev": true,
             "requires": {
                 "accepts": "~1.3.8",
                 "array-flatten": "1.1.1",
-                "body-parser": "1.20.0",
+                "body-parser": "1.20.2",
                 "content-disposition": "0.5.4",
                 "content-type": "~1.0.4",
-                "cookie": "0.5.0",
+                "cookie": "0.6.0",
                 "cookie-signature": "1.0.6",
                 "debug": "2.6.9",
                 "depd": "2.0.0",
@@ -29948,7 +29948,7 @@
                 "parseurl": "~1.3.3",
                 "path-to-regexp": "0.1.7",
                 "proxy-addr": "~2.0.7",
-                "qs": "6.10.3",
+                "qs": "6.11.0",
                 "range-parser": "~1.2.1",
                 "safe-buffer": "5.2.1",
                 "send": "0.18.0",
@@ -35431,9 +35431,9 @@
             "dev": true
         },
         "qs": {
-            "version": "6.10.3",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
-            "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+            "version": "6.11.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+            "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
             "dev": true,
             "requires": {
                 "side-channel": "^1.0.4"
@@ -35479,9 +35479,9 @@
             "dev": true
         },
         "raw-body": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-            "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+            "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
             "dev": true,
             "requires": {
                 "bytes": "3.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10717,9 +10717,9 @@
             "dev": true
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.4",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
-            "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
+            "version": "1.15.6",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+            "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
             "dev": true,
             "funding": [
                 {
@@ -30279,9 +30279,9 @@
             "dev": true
         },
         "follow-redirects": {
-            "version": "1.15.4",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
-            "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
+            "version": "1.15.6",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+            "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
             "dev": true
         },
         "for-each": {

--- a/src/dispatch/RetryHttpHandler.ts
+++ b/src/dispatch/RetryHttpHandler.ts
@@ -16,7 +16,7 @@ export class RetryHttpHandler implements HttpHandler {
     public constructor(
         handler: HttpHandler,
         retries: number,
-        backoff: BackoffFunction = (n) => n * 2000
+        backoff: BackoffFunction = (n) => 2000 * Math.pow(2, n - 1)
     ) {
         this.handler = handler;
         this.retries = retries;

--- a/src/plugins/event-plugins/ResourcePlugin.ts
+++ b/src/plugins/event-plugins/ResourcePlugin.ts
@@ -1,5 +1,9 @@
 import { InternalPlugin } from '../InternalPlugin';
-import { getResourceFileType, shuffle } from '../../utils/common-utils';
+import {
+    getResourceFileType,
+    isPutRumEventsCall,
+    shuffle
+} from '../../utils/common-utils';
 import { ResourceEvent } from '../../events/resource-event';
 import { PERFORMANCE_RESOURCE_EVENT_TYPE } from '../utils/constant';
 import {
@@ -88,12 +92,8 @@ export class ResourcePlugin extends InternalPlugin {
         duration,
         transferSize
     }: PerformanceResourceTiming): void => {
-        const pathRegex =
-            /.*\/application\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/events/;
-        const entryUrl = new URL(name);
         if (
-            entryUrl.host === this.context.config.endpointUrl.host &&
-            pathRegex.test(entryUrl.pathname)
+            isPutRumEventsCall(name, this.context.config.endpointUrl.hostname)
         ) {
             // Ignore calls to PutRumEvents (i.e., the CloudWatch RUM data
             // plane), otherwise we end up in an infinite loop of recording

--- a/src/plugins/event-plugins/__tests__/ResourcePlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/ResourcePlugin.test.ts
@@ -95,32 +95,6 @@ describe('ResourcePlugin tests', () => {
         expect(record).not.toHaveBeenCalled();
     });
 
-    test('when resource is a PutRumEvents request with a path prefix then resource event is not recorded', async () => {
-        // Setup
-        doMockPerformanceObserver([putRumEventsGammaDocument]);
-
-        const plugin: ResourcePlugin = buildResourcePlugin();
-
-        // Run
-        plugin.load(context);
-
-        // Assert
-        expect(record).not.toHaveBeenCalled();
-    });
-
-    test('when resource is not a PutRumEvents request but has the same host then the resource event is recorded', async () => {
-        // Setup
-        doMockPerformanceObserver([dataPlaneDocument]);
-
-        const plugin: ResourcePlugin = buildResourcePlugin();
-
-        // Run
-        plugin.load(context);
-
-        // Assert
-        expect(record).toHaveBeenCalled();
-    });
-
     test('when enabled then events are recorded', async () => {
         // Setup
         const plugin: ResourcePlugin = buildResourcePlugin();

--- a/src/plugins/utils/http-utils.ts
+++ b/src/plugins/utils/http-utils.ts
@@ -59,6 +59,8 @@ export const defaultConfig: HttpPluginConfig = {
     addXRayTraceIdHeader: false
 };
 
+export const is2xx = (status: number) => 200 <= status && status < 300;
+
 export const is4xx = (status: number) => {
     return Math.floor(status / 100) === 4;
 };

--- a/src/utils/__tests__/common-utils.test.ts
+++ b/src/utils/__tests__/common-utils.test.ts
@@ -105,4 +105,33 @@ describe('Common utils tests', () => {
             utils.getResourceFileType(resourceUrl, utils.InitiatorType.CSS)
         ).toEqual(utils.ResourceType.STYLESHEET);
     });
+
+    test('when url is has endpoint host and path then it is a PutRumEvents call', async () => {
+        const endpointHost = 'https://dataplane.rum.us-west-2.amazonaws.com';
+        const resourceUrl =
+            'https://dataplane.rum.us-west-2.amazonaws.com/gamma/application/aa17a42c-e737-48f7-adaf-2e0905f48073/events';
+        expect(utils.isPutRumEventsCall(resourceUrl, endpointHost)).toBe(true);
+    });
+
+    test('when url has endpoint host but wrong path then it is not a PutRumEvents call', async () => {
+        const endpointHost = 'https://dataplane.rum.us-west-2.amazonaws.com';
+        const resourceUrl =
+            'https://dataplane.rum.us-west-2.amazonaws.com/user';
+        expect(utils.isPutRumEventsCall(resourceUrl, endpointHost)).toBe(false);
+    });
+
+    test('when url has wrong host and wrong path then it is not a PutRumEvents call', async () => {
+        const endpointHost = 'https://example.com';
+        const resourceUrl =
+            'https://dataplane.rum.us-west-2.amazonaws.com/user';
+        expect(utils.isPutRumEventsCall(resourceUrl, endpointHost)).toBe(false);
+    });
+
+    test('when url is invalid then it is not a PutRumEvents call', async () => {
+        const endpointHost = 'dataplane.rum.us-west-2.amazonaws.com';
+        const resourceUrl =
+            'dataplane.rum.us-west-2.amazonaws.com/gamma/application/aa17a42c-e737-48f7-adaf-2e0905f48073/events';
+        expect(() => new URL(endpointHost)).toThrowError();
+        expect(utils.isPutRumEventsCall(resourceUrl, endpointHost)).toBe(false);
+    });
 });

--- a/src/utils/common-utils.ts
+++ b/src/utils/common-utils.ts
@@ -222,3 +222,22 @@ export const isFCPSupported = () => {
 export const isLongTaskSupported = () => {
     return PerformanceObserver.supportedEntryTypes.includes('longtask');
 };
+
+/** PutRumEvents regex pattern */
+const putRumEventsPattern =
+    /.*\/application\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/events/;
+
+export const isPutRumEventsCall = (
+    url: string,
+    endpointHost: string
+): boolean => {
+    try {
+        return (
+            new URL(url).hostname === endpointHost &&
+            putRumEventsPattern.test(url)
+        );
+    } catch (_) {
+        // Ignore invalid URLs
+        return false;
+    }
+};


### PR DESCRIPTION
This PR fixes two problems

1. JSErrors are being polluted by invalid urls
2. Resources with invalid URLs are being lost

With this PR, we are also adding the assumption that when a url is invalid, then it is not a put rum event call. My only remaining concern is that we do not understand why invalid urls are being created, and if they could be put rum event calls. But that is probably a very rare edge case. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
